### PR TITLE
Count unsubscriber

### DIFF
--- a/src/mailman/app/membership.py
+++ b/src/mailman/app/membership.py
@@ -100,13 +100,15 @@ def add_member(mlist, record, role=MemberRole.member):
 
 
 
-def delete_member(mlist, email, admin_notif=None, userack=None):
+def delete_member(mlist, email, channel, admin_notif=None, userack=None):
     """Delete a member right now.
 
     :param mlist: The mailing list to remove the member from.
     :type mlist: `IMailingList`
     :param email: The email address to unsubscribe.
     :type email: string
+    :param channel: the mode of unsubscription
+    :type channel: string
     :param admin_notif: Whether the list administrator should be notified that
         this member was deleted.
     :type admin_notif: bool, or None to let the mailing list's
@@ -123,7 +125,7 @@ def delete_member(mlist, email, admin_notif=None, userack=None):
     if member is None:
         raise NotAMemberError(mlist, email)
     language = member.preferred_language
-    member.unsubscribe()
+    member.unsubscribe(channel)
     # And send an acknowledgement to the user...
     if userack:
         send_goodbye_message(mlist, email, language)

--- a/src/mailman/commands/eml_membership.py
+++ b/src/mailman/commands/eml_membership.py
@@ -194,7 +194,7 @@ You may be asked to confirm your request.""")
                 '$self.name: $email is not a member of $mlist.fqdn_listname'),
                 file=results)
             return ContinueProcessing.no
-        member.unsubscribe()
+        member.unsubscribe('email confirmation')
         person = formataddr((user.display_name, email))
         print(_('$person left $mlist.fqdn_listname'), file=results)
         return ContinueProcessing.yes

--- a/src/mailman/interfaces/member.py
+++ b/src/mailman/interfaces/member.py
@@ -30,6 +30,7 @@ __all__ = [
     'NotAMemberError',
     'SubscriptionEvent',
     'UnsubscriptionEvent',
+    'IUnsubscriber',
     ]
 
 
@@ -38,7 +39,7 @@ from mailman.core.errors import MailmanError
 from zope.interface import Interface, Attribute
 
 
-
+
 class DeliveryMode(Enum):
     # Regular (i.e. non-digest) delivery
     regular = 1
@@ -50,7 +51,7 @@ class DeliveryMode(Enum):
     summary_digests = 4
 
 
-
+
 class DeliveryStatus(Enum):
     # Delivery is enabled
     enabled = 1
@@ -64,7 +65,7 @@ class DeliveryStatus(Enum):
     unknown = 5
 
 
-
+
 class MemberRole(Enum):
     member = 1
     owner = 2
@@ -72,7 +73,7 @@ class MemberRole(Enum):
     nonmember = 4
 
 
-
+
 class MembershipChangeEvent:
     """Base class for subscription/unsubscription events."""
 
@@ -100,7 +101,7 @@ class UnsubscriptionEvent(MembershipChangeEvent):
         return '{0} left {1}'.format(self.member.address, self.mlist.list_id)
 
 
-
+
 class MembershipError(MailmanError):
     """Base exception for all membership errors."""
 
@@ -156,7 +157,7 @@ class NotAMemberError(MembershipError):
             self._address, self._mlist)
 
 
-
+
 class IMember(Interface):
     """A member of a mailing list."""
 
@@ -193,7 +194,11 @@ class IMember(Interface):
         """The moderation action for this member as an `Action`.""")
 
     def unsubscribe():
-        """Unsubscribe (and delete) this member from the mailing list."""
+        """Unsubscribe (and delete) this member from the mailing list.
+        :param channel: channel of unsubscription
+        :type channel: str
+        """
+        
 
     acknowledge_posts = Attribute(
         """Send an acknowledgment for every posting?
@@ -275,3 +280,31 @@ class IMember(Interface):
         database, since a member's options aren't tied to any specific mailing
         list.  So in what part of the web-space does the user's options live?
         """)
+
+
+class IUnsubscriber(Interface):
+    """A member unsubscribed from a mailing list."""
+
+    list_id = Attribute(
+        """The list id of the mailing list the member is unsubscribed from.""")
+
+    address = Attribute(
+        """The email address that's unsubscribed from the list.""")
+
+    user = Attribute(
+        """The user associated with this unsubscriber.""")
+
+    role = Attribute(
+        """The role of the unsubscribing member""")
+
+    date_unsub = Attribute(
+        """The date on which member is unsubscribed""")
+
+    channel = Attribute(
+        """ The channel through which member is unsubscribing
+
+        This can be 'web-confirmation', 'email-confirmation'
+        'via the member options page', 'admin mass unsub' or 'disable'
+         """)
+
+

--- a/src/mailman/rest/members.py
+++ b/src/mailman/rest/members.py
@@ -157,24 +157,23 @@ class AMember(_MemberBase):
         
         arguments = {}
         if len(request.params.items()) == 0:
-           arguments['mode'] = None 
+           arguments['channel'] = None 
         else:
             try:
-                validator = Validator(mode=str)
+                validator = Validator(channel=str)
                 arguments = validator(request)
             except ValueError as error:
                  bad_request(response, str(error))
                  return
-
         mlist = getUtility(IListManager).get_by_list_id(self._member.list_id)
         if self._member.role is MemberRole.member:
             try:
-                delete_member(mlist, self._member.address.email, arguments['mode'], False, False)
+                delete_member(mlist, self._member.address.email, arguments['channel'], False, False)
             except NotAMemberError:
                 not_found(response)
                 return
         else:
-            self._member.unsubscribe(arguments['mode'])
+            self._member.unsubscribe(arguments['channel'])
         no_content(response)
 
     def on_patch(self, request, response):

--- a/src/mailman/rest/root.py
+++ b/src/mailman/rest/root.py
@@ -40,6 +40,7 @@ from mailman.rest.preferences import ReadOnlyPreferences
 from mailman.rest.queues import AQueue, AQueueFile, AllQueues
 from mailman.rest.templates import TemplateFinder
 from mailman.rest.users import AUser, AllUsers
+from mailman.rest.unsubscriber import Unsubscriber
 from zope.component import getUtility
 
 
@@ -255,3 +256,15 @@ class TopLevel:
     def reserved(self, request, segments):
         """/<api>/reserved/[...]"""
         return Reserved(segments), []
+
+    @child()
+    def unsubscriber(self, request, segments):
+        """/<api>/unsubscriber/<fqdn_listname>"""
+        if len(segments) == 1:
+            return Unsubscriber(segments[0]), []
+        else:
+            return BadRequest(), []
+
+
+
+

--- a/src/mailman/rest/unsubscriber.py
+++ b/src/mailman/rest/unsubscriber.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2010-2015 by the Free Software Foundation, Inc.
+#
+# This file is part of GNU Mailman.
+#
+# GNU Mailman is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# GNU Mailman is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# GNU Mailman.  If not, see <http://www.gnu.org/licenses/>.
+
+"""REST for unsubscribers."""
+
+__all__ = [
+    'Unsubscriber',
+    ]
+
+from mailman.interfaces.listmanager import IListManager
+from mailman.rest.helpers import (
+    CollectionMixin, bad_request,etag, no_content,  okay)
+from mailman.rest.validator import Validator
+from zope.component import getUtility
+from mailman.model.member import Unsubscriber
+from mailman.model import mailinglist
+from mailman.model.roster import Unsubscribers 
+import datetime
+
+
+CHANNELS = ('email confirmation',
+            'member options page',
+            'admin mass removal',
+            'disable')
+
+
+class Unsubscriber(CollectionMixin):
+    """/unsubscriber/listname"""
+    
+    def _resource_as_dict(self, result):
+        """See `CollectionMixin`."""
+        return dict (no_of_unsubscriber = result)
+
+    def __init__(self, list_identifier):
+        list_manager = getUtility(IListManager)
+        if '@' in list_identifier:
+            self._mlist = list_manager.get(list_identifier)
+        else:
+            self._mlist = list_manager.get_by_list_id(list_identifier)
+
+    def get_count(self, start_date=None, stop_date=None):
+        result = ""
+        total = 0
+        unsub_roster = Unsubscribers(self._mlist)
+        # reporting the unsubscribers via all the possible modes
+        for channel in CHANNELS:
+            if start_date and stop_date:
+                count = unsub_roster.countUnsubscribers(channel, start_date, stop_date)
+            else:
+                count = unsub_roster.countUnsubscribers(channel)
+            if count == 'db-error':
+                return 'A database error occurred while retrieving the unsubscriber count.'
+            total += int(0 if count is None else count)
+            result += "The number of unsubscribers via \""+channel+"\": "+str(count)+"\n"
+        result += "Total number of unsubscribers: "+str(total)
+        return result
+
+    def on_get(self, request, response):
+        """return no of unsubscribers for different channels"""
+        if self._mlist is None:
+            bad_request(response, 'No such list')
+            return
+        result = self.get_count()
+        okay(response, self._resource_as_json(result))
+
+    def on_post(self, request, response):
+        """return no of unsubscribers for different channels for a specific time period"""
+        if self._mlist is None:
+            bad_request(response, 'No such list')
+            return
+
+        validator = Validator(
+            start_date=str,
+            stop_date=str
+            )
+        try:
+            values = validator(request)
+        except ValueError as error:
+            bad_request(response, str(error))
+            return
+        result = self.get_count(values['start_date'], values['stop_date'])
+        okay(response, self._resource_as_json(result))


### PR DESCRIPTION


Made changes in the Mailman Core, majorly the REST and the models to:
-create a new table to save information like date and channel of unsubscription
-identify channels (like email confirmation and member options page) in the unsubscription request and save to the database
-REST API to retrieve the count of unsubscribers (through a HTTP request by the mailman client)

More on the feature : http://systersmailman.blogspot.in/2015/06/feature-to-get-stats-for-number-of.html
